### PR TITLE
0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.0.3](https://github.com/jmeas/resourceful-redux/releases/tag/0.0.4) (6/19/17)
+
+**New Features**
+
+- A "null" property is now included in the object returned from `getStatus`,
+  which can be used to check if the request status is `"NULL"`.
+
 ## [0.0.3](https://github.com/jmeas/resourceful-redux/releases/tag/0.0.3) (6/19/17)
 
 - Passing an empty resources array in an action creator with `mergeLabelIds: false`

--- a/docs/api-reference/get-status.md
+++ b/docs/api-reference/get-status.md
@@ -1,4 +1,4 @@
-# `getStatus(state, statusLocations, [isNullPending])`
+# `getStatus(state, statusLocations, [treatNullAsPending])`
 
 Returns an object with boolean values representing the request status of a
 particular CRUD action. It can also be used to aggregate multiple request
@@ -11,7 +11,7 @@ statuses together.
 3. `statusLocations` *(Array)*: An Array of paths that point to request statuses
   within `state`. For more on status locations, see the Notes below.
 
-4. [`isNullPending`] *(Boolean)*: Whether or not a request status of `NULL` is
+4. [`treatNullAsPending`] *(Boolean)*: Whether or not a request status of `NULL` is
   to be considered as a `pending` request. Defaults to `false`. See Tips on
   when to use this.
 
@@ -22,22 +22,23 @@ statuses together.
 
   ```js
   {
+    null: Boolean,
     pending: Boolean,
     failed: Boolean,
     succeeded: Boolean
   }
   ```
 
-  At most, one of these values will be `true`. When `isNullPending` is `true`,
-  then you can be certain that one of these will _always_ be true. When
-  `isNullPending` is `false`, all three values will be `false` when all of the
-  request statuses are `NULL`.
+  One of these values is always `true`, reflecting the value of the request
+  status. When `treatNullAsPending` is `true`, then request statuses that are
+  `"NULL"` will be returned as `pending: true`.
 
 #### Notes
 
 Passing more than one status location will aggregate the statuses. The rules of
 aggregation work as follows:
 
+- If all of the requests are null, then the aggregate is null
 - If *any* of the requests are failed, then the aggregate is failed.
 - If no requests have failed, but some are pending, then the aggregate is pending.
 - If all requests have succeeded, then the aggregate has succeeded.
@@ -45,6 +46,8 @@ aggregation work as follows:
 A status location is a string that specifies a location of a request status in
 your state tree. For instance `"books.meta.24.readStatus"` or
 `"books.labels.dashboardSearch.status"`.
+
+> Keep in mind that `treatNullAsPending` also works when aggregating.
 
 #### Example
 
@@ -65,9 +68,9 @@ const bookReadStatus = getStatus(
 
 #### Tips
 
-- The third argument, `isNullPending`, is useful for requests that are made when
+- The third argument, `treatNullAsPending`, is useful for requests that are made when
   your components mount. The components will often render before the request
-  begins, so the status of these requests will be `NULL`. Passing `isNullPending`
+  begins, so the status of these requests will be `NULL`. Passing `treatNullAsPending`
   will consider these `NULL` states as `pending: true`.
 
 - If you're using React, we recommend computing your `getStatus` values in

--- a/docs/api-reference/get-status.md
+++ b/docs/api-reference/get-status.md
@@ -1,4 +1,4 @@
-# `getStatus(state, metaLocations, [isNullPending])`
+# `getStatus(state, statusLocations, [isNullPending])`
 
 Returns an object with boolean values representing the request status of a
 particular CRUD action. It can also be used to aggregate multiple request
@@ -8,8 +8,8 @@ statuses together.
 
 1. `state` *(Object)*: The current state of the Redux store.
 
-3. `metaLocations` *(Array)*: An Array of "meta locations" to get the status
-  from. For more on meta locations, see the Notes below.
+3. `statusLocations` *(Array)*: An Array of paths that point to request statuses
+  within `state`. For more on status locations, see the Notes below.
 
 4. [`isNullPending`] *(Boolean)*: Whether or not a request status of `NULL` is
   to be considered as a `pending` request. Defaults to `false`. See Tips on
@@ -18,7 +18,7 @@ statuses together.
 #### Returns
 
 (*`Object`*): An Object representing the status of this request for these
-  metaLocations. It has the following shape:
+  statusLocations. It has the following shape:
 
   ```js
   {
@@ -35,15 +35,16 @@ statuses together.
 
 #### Notes
 
-Passing more than one meta location will aggregate the statuses. The rules of
+Passing more than one status location will aggregate the statuses. The rules of
 aggregation work as follows:
 
 - If *any* of the requests are failed, then the aggregate is failed.
 - If no requests have failed, but some are pending, then the aggregate is pending.
 - If all requests have succeeded, then the aggregate has succeeded.
 
-A meta location is a string that specifies a location in your store. For
-instance `"books.meta.24.readStatus"` or `"books.labels.dashboardSearch.status"`.
+A status location is a string that specifies a location of a request status in
+your state tree. For instance `"books.meta.24.readStatus"` or
+`"books.labels.dashboardSearch.status"`.
 
 #### Example
 

--- a/docs/guides/request-statuses.md
+++ b/docs/guides/request-statuses.md
@@ -103,13 +103,13 @@ The rules of aggregation work as follows:
 
 At most, only one of these values will ever be `true`.
 
-If `isNullPending` (the third argument, see below) is `false`, then all three
+If `treatNullAsPending` (the third argument, see below) is `false`, then all three
 values will be `false` if all of the request statuses in the state tree are
 `"NULL"`.
 
-### `isNullPending`
+### `treatNullAsPending`
 
-The third argument to `getStatus` is a Boolean called `isNullPending`. It
+The third argument to `getStatus` is a Boolean called `treatNullAsPending`. It
 determines whether a request status of `"NULL"` will count as `pending` or not.
 
 Consider an interface that loads a particular book when the page loads. Right
@@ -119,7 +119,15 @@ will have a value of `"NULL"`.
 
 If you don't pass `true`, then there will be a "flash of no content" unless
 you explicitly check for the `"NULL"` status yourself. To avoid this, pass
-`isNullPending` as true, and `getStatus` will instead consider that to be a
+`treatNullAsPending` as true, and `getStatus` will instead consider that to be a
 pending state.
 
-The default value of `isNullPending` is `false`.
+The default value of `treatNullAsPending` is `false`.
+
+##### The Rule of Thumb
+
+There is a rule of thumb for using `treatNullAsPending`:
+
+- For requests that happen when the page loads, pass `treatNullAsPending` as `true`
+- For requests that happen as a response to a user's action (such as clicking a
+  button), pass `treatNullAsPending` as `false`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourceful-redux",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A powerful Redux framework for interacting with remote resources.",
   "main": "dist/resourceful-redux.js",
   "scripts": {

--- a/src/utils/get-status.js
+++ b/src/utils/get-status.js
@@ -1,7 +1,7 @@
 import requestStatuses from './request-statuses';
 
-function getSingleStatus(state, metaLocation, isNullPending) {
-  const splitPath = metaLocation.split('.');
+function getSingleStatus(state, statusLocation, isNullPending) {
+  const splitPath = statusLocation.split('.');
 
   let status;
   let currentVal = state;
@@ -27,11 +27,11 @@ function getSingleStatus(state, metaLocation, isNullPending) {
   };
 }
 
-// Returns the status of a particular CRUD action based on `metaLocation`.
+// Returns the status of a particular CRUD action based on `statusLocation`.
 //
 // `state`: A piece of the Redux store containing the relevant resources
 // `action`: The CRUD action in question
-// `metaLocation`: A location of the meta resource (see `find-meta.js` for more)
+// `statusLocation`: A location of the meta resource (see `find-meta.js` for more)
 // `isNullPending`: Whether or not to count a status of `NULL` as pending.
 //
 // Returns an Object with the following properties:
@@ -44,12 +44,12 @@ function getSingleStatus(state, metaLocation, isNullPending) {
 //
 // Note that at most _one_ of those properties will be true. It is
 // possible for them to all be false.
-export default function getStatus(state, metaLocations, isNullPending) {
-  if (!(metaLocations instanceof Array)) {
-    return getSingleStatus(state, metaLocations, isNullPending);
+export default function getStatus(state, statusLocations, isNullPending) {
+  if (!(statusLocations instanceof Array)) {
+    return getSingleStatus(state, statusLocations, isNullPending);
   }
 
-  const statusValues = metaLocations.map(loc => getSingleStatus(state, loc, isNullPending));
+  const statusValues = statusLocations.map(loc => getSingleStatus(state, loc, isNullPending));
 
   let pending = false;
   let failed = false;

--- a/test/unit/utils/get-status.js
+++ b/test/unit/utils/get-status.js
@@ -37,6 +37,7 @@ describe('getStatus', function() {
   describe('singular', () => {
     it('should return a meta that exists', () => {
       expect(getStatus(this.state, 'sandwiches.meta.102.readStatus')).to.deep.equal({
+        null: false,
         pending: false,
         failed: false,
         succeeded: true
@@ -45,6 +46,7 @@ describe('getStatus', function() {
 
     it('should return a label meta that exists', () => {
       expect(getStatus(this.state, 'books.labels.dashboardSearch.status')).to.deep.equal({
+        null: false,
         pending: false,
         failed: false,
         succeeded: true
@@ -53,14 +55,16 @@ describe('getStatus', function() {
 
     it('should return a meta that exists and is null', () => {
       expect(getStatus(this.state, 'sandwiches.meta.100.readStatus')).to.deep.equal({
+        null: true,
         pending: false,
         failed: false,
         succeeded: false
       });
     });
 
-    it('should return a meta that exists and is null with `isNullPending` set to true', () => {
+    it('should return a meta that exists and is null with `treatNullAsPending` set to true', () => {
       expect(getStatus(this.state, 'sandwiches.meta.100.read', true)).to.deep.equal({
+        null: false,
         pending: true,
         failed: false,
         succeeded: false
@@ -69,14 +73,16 @@ describe('getStatus', function() {
 
     it('should return a meta that does exist', () => {
       expect(getStatus(this.state, 'books.meta.10.update')).to.deep.equal({
+        null: true,
         pending: false,
         failed: false,
         succeeded: false
       });
     });
 
-    it('should return a meta that does not exist with `isNullPending` set to true', () => {
+    it('should return a meta that does not exist with `treatNullAsPending` set to true', () => {
       expect(getStatus(this.state, 'books.10.update', true)).to.deep.equal({
+        null: false,
         pending: true,
         failed: false,
         succeeded: false
@@ -92,6 +98,7 @@ describe('getStatus', function() {
       );
 
       expect(result).to.deep.equal({
+        null: false,
         pending: false,
         failed: true,
         succeeded: false
@@ -105,13 +112,14 @@ describe('getStatus', function() {
       );
 
       expect(result).to.deep.equal({
+        null: true,
         pending: false,
         failed: false,
         succeeded: false
       });
     });
 
-    it('should return combined resource read statuses with `isNullPending`', () => {
+    it('should return combined resource read statuses with `treatNullAsPending`', () => {
       const result = getStatus(
         this.state,
         ['sandwiches.meta.100.readStatus', 'sandwiches.meta.102.readStatus'],
@@ -119,6 +127,7 @@ describe('getStatus', function() {
       );
 
       expect(result).to.deep.equal({
+        null: false,
         pending: true,
         failed: false,
         succeeded: false
@@ -132,6 +141,7 @@ describe('getStatus', function() {
       );
 
       expect(result).to.deep.equal({
+        null: false,
         pending: false,
         failed: false,
         succeeded: true
@@ -149,6 +159,7 @@ describe('getStatus', function() {
       );
 
       expect(result).to.deep.equal({
+        null: false,
         pending: false,
         failed: true,
         succeeded: false


### PR DESCRIPTION
Resolves #14
Resolves #16 

Using `null` as a property may be temporary (see #18). But it's useful, so it's going in the release!