### PR TITLE
Add missing json xhr option in guide

### DIFF
--- a/docs/api-reference/action-types.md
+++ b/docs/api-reference/action-types.md
@@ -54,7 +54,7 @@ export default function readBook(bookId) {
       resources: [bookId]
     });
 
-    const req = xhr.get(`/books/${bookId}`, (err, res) => {
+    const req = xhr.get(`/books/${bookId}`, {json: true}, (err, res) => {
       if (req.aborted) {
         dispatch({
           type: actionTypes.READ_RESOURCES_NULL,

--- a/docs/guides/reading-resources.md
+++ b/docs/guides/reading-resources.md
@@ -70,6 +70,7 @@ export default function readBook(bookId) {
 
     const req = xhr.get(
       `/books/${bookId}`,
+      {json: true},
       (err, res, body) => {
         if (req.aborted) {
           dispatch({
@@ -123,6 +124,7 @@ export default function readBooks(query) {
 
     const req = xhr.get(
       `/books?${queryString}`,
+      {json: true},
       (err, res, body) => {
         if (req.aborted) {
           dispatch({


### PR DESCRIPTION
I was following along the docs and noticed the example for [Reading Resources](https://resourceful-redux.js.org/docs/guides/reading-resources.html#example-action-creator-reading-one-resource) was missing the json xhr option in the requests.