### PR TITLE
Better handling of poorly-formatted actions

### DIFF
--- a/packages/resourceful-redux/src/reducers/delete.js
+++ b/packages/resourceful-redux/src/reducers/delete.js
@@ -8,8 +8,12 @@ const delFail = reducerGenerator('delete', requestStatuses.FAILED);
 const delNull = reducerGenerator('delete', requestStatuses.NULL);
 
 function delSucceed(state, action, {initialResourceMeta}) {
-  const label = action.label;
   const resources = action.resources;
+
+  let label;
+  if (action.label && typeof action.label === 'string') {
+    label = action.label;
+  }
 
   if (process.env.NODE_ENV !== 'production') {
     if (!resources) {

--- a/packages/resourceful-redux/src/resource-reducer.js
+++ b/packages/resourceful-redux/src/resource-reducer.js
@@ -44,6 +44,13 @@ export default function resourceReducer(resourceName, options = {}) {
           `https://resourceful-redux.js.org/docs/guides/crud-actions.html`
         );
       }
+
+      if (action.label && typeof action.label !== 'string') {
+        warning(
+          `An invalid label was included in an action with type ` +
+          `"${action.type}". Labels must be strings.`
+        );
+      }
     }
 
     // We only call the built-in reducers if the action type matches one,

--- a/packages/resourceful-redux/src/utils/cru-reducer-helper.js
+++ b/packages/resourceful-redux/src/utils/cru-reducer-helper.js
@@ -7,9 +7,13 @@ import warning from './warning';
 
 export default function(state, action, {initialResourceMeta}, updatedMeta) {
   const resources = action.resources;
-  const label = action.label;
   const resourcesIsUndefined = typeof resources === 'undefined';
   const hasResources = resources && resources.length;
+
+  let label;
+  if (action.label && typeof action.label === 'string') {
+    label = action.label;
+  }
 
   if (process.env.NODE_ENV !== 'production') {
     if (!resources) {

--- a/packages/resourceful-redux/src/utils/reducer-generator.js
+++ b/packages/resourceful-redux/src/utils/reducer-generator.js
@@ -16,8 +16,12 @@ import warning from './warning';
 export default function(crudAction, requestStatus) {
   return function(state, action, {initialResourceMeta} = {}) {
     const resources = action.resources;
-    const label = action.label;
     const mergeMeta = action.mergeMeta;
+
+    let label;
+    if (action.label && typeof action.label === 'string') {
+      label = action.label;
+    }
 
     let idList;
     if (resources) {

--- a/packages/resourceful-redux/src/utils/set-resource-meta.js
+++ b/packages/resourceful-redux/src/utils/set-resource-meta.js
@@ -13,6 +13,14 @@ export default function setResourceMeta(options) {
 
   resources.forEach((resource) => {
     const id = typeof resource === 'object' ? resource.id : resource;
+
+    // If we have no ID for this resource, then we bail. This currently isn't
+    // logging so that we don't double-blast the user with meta **and**
+    // attribute update problems.
+    if (!id) {
+      return;
+    }
+
     const currentMeta = next[id];
 
     let startMeta;

--- a/packages/resourceful-redux/src/utils/set-resource-meta.js
+++ b/packages/resourceful-redux/src/utils/set-resource-meta.js
@@ -14,10 +14,12 @@ export default function setResourceMeta(options) {
   resources.forEach((resource) => {
     const id = typeof resource === 'object' ? resource.id : resource;
 
-    // If we have no ID for this resource, then we bail. This currently isn't
-    // logging so that we don't double-blast the user with meta **and**
-    // attribute update problems.
-    if (!id) {
+    // If we have no ID for this resource, or if its not a number or string,
+    // then we bail. This currently isn't logging so that we don't double-blast
+    // the user with meta **and** attribute update problems. If the ID check
+    // is moved into the success reducers directly, then we may be able to
+    // remove these typeof checks for efficiency.
+    if (!id || (typeof id !== 'string' && typeof id !== 'number')) {
       return;
     }
 

--- a/packages/resourceful-redux/test/unit/reducers/delete.js
+++ b/packages/resourceful-redux/test/unit/reducers/delete.js
@@ -191,6 +191,85 @@ describe('reducers: delete', function() {
       expect(console.error.callCount).to.equal(0);
     });
 
+    it('warns and ignores a poorly-formatted label', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: {id: 1},
+            3: {id: 3},
+            4: {id: 4},
+          },
+          labels: {
+            oink: {
+              hungry: true,
+              ids: [10, 3]
+            },
+            italiano: {
+              status: requestStatuses.PENDING,
+              ids: [1, 3, 4],
+              hangry: false
+            }
+          },
+          meta: {
+            1: {
+              name: 'what'
+            },
+            3: {
+              deleteStatus: 'sandwiches'
+            }
+          }
+        }
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'DELETE_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+        label: {},
+        resources: [
+          3,
+          {id: 4}
+        ]
+      });
+
+      expect(reduced).to.deep.equal({
+        resources: {
+          1: {id: 1},
+          3: null,
+          4: null
+        },
+        labels: {
+          italiano: {
+            status: requestStatuses.PENDING,
+            ids: [1],
+            hangry: false
+          },
+          oink: {
+            ids: [10],
+            hungry: true
+          }
+        },
+        meta: {
+          1: {
+            name: 'what'
+          },
+          3: {
+            createStatus: requestStatuses.NULL,
+            readStatus: requestStatuses.NULL,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.SUCCEEDED
+          },
+          4: {
+            createStatus: requestStatuses.NULL,
+            readStatus: requestStatuses.NULL,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.SUCCEEDED
+          }
+        }
+      });
+      expect(console.error.callCount).to.equal(1);
+    });
+
     it('returns the right state with a label, with IDs', () => {
       stub(console, 'error');
       const reducer = resourceReducer('hellos', {

--- a/packages/resourceful-redux/test/unit/reducers/read.js
+++ b/packages/resourceful-redux/test/unit/reducers/read.js
@@ -2,12 +2,47 @@ import {resourceReducer, requestStatuses} from '../../../src';
 
 describe('reducers: read:', function() {
   describe('READ_RESOURCES_PENDING:', () => {
-    const reducer = resourceReducer('hellos', {
-      initialState: {
+    it('should warn and not set a badly configured label', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: {id: 1},
+            3: {id: 3},
+            4: {id: 4, lastName: 'camomile'},
+          },
+          labels: {},
+          meta: {
+            1: {
+              name: 'what'
+            },
+            3: {
+              deleteStatus: 'sandwiches'
+            },
+            4: {
+              createStatus: requestStatuses.SUCCEEDED,
+              selected: true
+            }
+          }
+        },
+        initialResourceMeta: {
+          selected: false,
+          createStatus: requestStatuses.PENDING
+        }
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'READ_RESOURCES_PENDING',
+        resourceName: 'hellos',
+        label: true,
+        resources: [4, 5]
+      });
+
+      expect(reduced).to.deep.equal({
         resources: {
           1: {id: 1},
           3: {id: 3},
-          4: {id: 4, lastName: 'camomile'},
+          4: {id: 4, lastName: 'camomile'}
         },
         labels: {},
         meta: {
@@ -18,52 +53,90 @@ describe('reducers: read:', function() {
             deleteStatus: 'sandwiches'
           },
           4: {
+            selected: true,
             createStatus: requestStatuses.SUCCEEDED,
-            selected: true
+            readStatus: requestStatuses.PENDING,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.NULL,
+          },
+          5: {
+            selected: false,
+            createStatus: requestStatuses.PENDING,
+            readStatus: requestStatuses.PENDING,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.NULL,
           }
         }
-      },
-      initialResourceMeta: {
-        selected: false,
-        createStatus: requestStatuses.PENDING
-      }
+      });
+      expect(console.error.callCount).to.equal(1);
     });
 
-    const reduced = reducer(undefined, {
-      type: 'READ_RESOURCES_PENDING',
-      resourceName: 'hellos',
-      resources: [4, 5]
-    });
-
-    expect(reduced).to.deep.equal({
-      resources: {
-        1: {id: 1},
-        3: {id: 3},
-        4: {id: 4, lastName: 'camomile'}
-      },
-      labels: {},
-      meta: {
-        1: {
-          name: 'what'
+    it('should return the correct state without erroring when called correctly', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: {id: 1},
+            3: {id: 3},
+            4: {id: 4, lastName: 'camomile'},
+          },
+          labels: {},
+          meta: {
+            1: {
+              name: 'what'
+            },
+            3: {
+              deleteStatus: 'sandwiches'
+            },
+            4: {
+              createStatus: requestStatuses.SUCCEEDED,
+              selected: true
+            }
+          }
         },
-        3: {
-          deleteStatus: 'sandwiches'
-        },
-        4: {
-          selected: true,
-          createStatus: requestStatuses.SUCCEEDED,
-          readStatus: requestStatuses.PENDING,
-          updateStatus: requestStatuses.NULL,
-          deleteStatus: requestStatuses.NULL,
-        },
-        5: {
+        initialResourceMeta: {
           selected: false,
-          createStatus: requestStatuses.PENDING,
-          readStatus: requestStatuses.PENDING,
-          updateStatus: requestStatuses.NULL,
-          deleteStatus: requestStatuses.NULL,
+          createStatus: requestStatuses.PENDING
         }
-      }
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'READ_RESOURCES_PENDING',
+        resourceName: 'hellos',
+        resources: [4, 5]
+      });
+
+      expect(reduced).to.deep.equal({
+        resources: {
+          1: {id: 1},
+          3: {id: 3},
+          4: {id: 4, lastName: 'camomile'}
+        },
+        labels: {},
+        meta: {
+          1: {
+            name: 'what'
+          },
+          3: {
+            deleteStatus: 'sandwiches'
+          },
+          4: {
+            selected: true,
+            createStatus: requestStatuses.SUCCEEDED,
+            readStatus: requestStatuses.PENDING,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.NULL,
+          },
+          5: {
+            selected: false,
+            createStatus: requestStatuses.PENDING,
+            readStatus: requestStatuses.PENDING,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.NULL,
+          }
+        }
+      });
+      expect(console.error.callCount).to.equal(0);
     });
   });
 
@@ -372,7 +445,93 @@ describe('reducers: read:', function() {
       });
     });
 
+    it('warns when a badly formatted label is passed in', () => {
+      stub(console, 'error');
+      const reducer = resourceReducer('hellos', {
+        initialState: {
+          resources: {
+            1: {id: 1},
+            3: {id: 3},
+            4: {id: 4, lastName: 'camomile'},
+          },
+          labels: {
+            sandwiches: {
+              ids: [1, 3],
+              status: requestStatuses.FAILED
+            },
+            pasta: {
+              ids: [4],
+              status: requestStatuses.PENDING
+            }
+          },
+          meta: {
+            1: {
+              name: 'what'
+            },
+            3: {
+              deleteStatus: 'sandwiches'
+            },
+            4: {
+              selected: true
+            }
+          }
+        }
+      });
+
+      const reduced = reducer(undefined, {
+        type: 'READ_RESOURCES_SUCCEEDED',
+        resourceName: 'hellos',
+        label: {},
+        resources: [
+          {id: 4, name: 'sandwiches'},
+          5
+        ]
+      });
+
+      expect(reduced).to.deep.equal({
+        resources: {
+          1: {id: 1},
+          3: {id: 3},
+          4: {id: 4, name: 'sandwiches', lastName: 'camomile'},
+          5: {id: 5}
+        },
+        labels: {
+          sandwiches: {
+            ids: [1, 3],
+            status: requestStatuses.FAILED
+          },
+          pasta: {
+            ids: [4],
+            status: requestStatuses.PENDING
+          }
+        },
+        meta: {
+          1: {
+            name: 'what'
+          },
+          3: {
+            deleteStatus: 'sandwiches'
+          },
+          4: {
+            selected: true,
+            createStatus: requestStatuses.NULL,
+            readStatus: requestStatuses.SUCCEEDED,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.NULL,
+          },
+          5: {
+            createStatus: requestStatuses.NULL,
+            readStatus: requestStatuses.SUCCEEDED,
+            updateStatus: requestStatuses.NULL,
+            deleteStatus: requestStatuses.NULL,
+          }
+        }
+      });
+      expect(console.error.callCount).to.equal(1);
+    });
+
     it('returns state with resource object and label, ensuring no label ID dupes', () => {
+      stub(console, 'error');
       const reducer = resourceReducer('hellos', {
         initialState: {
           resources: {
@@ -453,6 +612,7 @@ describe('reducers: read:', function() {
           }
         }
       });
+      expect(console.error.callCount).to.equal(0);
     });
 
     it('returns state with resource object and label, ensuring empty label IDs works', () => {

--- a/packages/resourceful-redux/test/unit/utils/set-resource-meta.js
+++ b/packages/resourceful-redux/test/unit/utils/set-resource-meta.js
@@ -37,6 +37,26 @@ describe('setResourceMeta', function() {
       expect(result[1]).to.not.equal(this.meta[1]);
       expect(result[2]).to.not.equal(this.meta[2]);
     });
+
+    it('should ignore badly formed resources', () => {
+      const result = setResourceMeta({
+        meta: this.meta,
+        newMeta: {isSelected: true},
+        resources: [1, {name: 'pasta'}],
+        mergeMeta: false
+      });
+
+      expect(result).to.deep.equal({
+        1: {isSelected: true},
+        2: {thirsty: true},
+        3: {what: false}
+      });
+
+      // The original `meta` is shallow cloned
+      expect(result).to.not.equal(this.meta);
+      // The existing item is not modified
+      expect(result[1]).to.not.equal(this.meta[1]);
+    });
   });
 
   describe('mergeMeta: true', () => {

--- a/packages/resourceful-redux/test/unit/utils/set-resource-meta.js
+++ b/packages/resourceful-redux/test/unit/utils/set-resource-meta.js
@@ -38,11 +38,31 @@ describe('setResourceMeta', function() {
       expect(result[2]).to.not.equal(this.meta[2]);
     });
 
-    it('should ignore badly formed resources', () => {
+    it('should ignore badly formed resources, object form (gh-118)', () => {
       const result = setResourceMeta({
         meta: this.meta,
         newMeta: {isSelected: true},
         resources: [1, {name: 'pasta'}],
+        mergeMeta: false
+      });
+
+      expect(result).to.deep.equal({
+        1: {isSelected: true},
+        2: {thirsty: true},
+        3: {what: false}
+      });
+
+      // The original `meta` is shallow cloned
+      expect(result).to.not.equal(this.meta);
+      // The existing item is not modified
+      expect(result[1]).to.not.equal(this.meta[1]);
+    });
+
+    it('should ignore badly formed resources, non-object form (gh-118)', () => {
+      const result = setResourceMeta({
+        meta: this.meta,
+        newMeta: {isSelected: true},
+        resources: [1, {id: {}}],
         mergeMeta: false
       });
 


### PR DESCRIPTION
Resolves #118 

- If you pass an invalid label, it'll be ignored
- If you pass a resource without IDs, it will no longer set the meta on `slice.meta.undefined`