### PR TITLE
Add reset plugin

### DIFF
--- a/packages/resourceful-plugins/src/reset.js
+++ b/packages/resourceful-plugins/src/reset.js
@@ -1,0 +1,47 @@
+import {requestStatuses} from 'resourceful-redux';
+
+const actionTypes = {
+  RESET_RESOURCE: 'RESET_RESOURCE'
+};
+
+function resetResource(resourceName, label) {
+  return {
+    type: 'RESET_RESOURCE',
+    resourceName,
+    label
+  };
+}
+
+function reset(resourceName, options = {}) {
+  return function(state, action) {
+    if (action.type !== actionTypes.RESET_RESOURCE || action.resourceName !== resourceName) {
+      return state;
+    }
+
+    const {label} = action;
+
+    if (!label) {
+      return {
+        resources: {},
+        meta: {},
+        labels: {},
+        ...options.initialState,
+      };
+    }
+
+    else {
+      return {
+        ...state,
+        labels: {
+          ...state.labels,
+          [label]: {
+            ids: [],
+            status: requestStatuses.NULL
+          }
+        }
+      };
+    }
+  };
+}
+
+export {actionTypes, resetResource, reset};

--- a/packages/resourceful-plugins/test/unit/reset.js
+++ b/packages/resourceful-plugins/test/unit/reset.js
@@ -1,0 +1,135 @@
+import {resetResource, reset} from '../../src/reset';
+
+describe('reset', function() {
+  beforeEach(() => {
+    stub(console, 'error');
+  });
+
+  it('should not change the state when the resource name does not match', () => {
+    const reducer = reset('books');
+
+    const state = {
+      selectedIds: [24],
+      resources: {
+        24: {name: 'James'}
+      },
+      meta: {
+        24: {oinky: true}
+      },
+      labels: {
+        pasta: {
+          ids: [24],
+          status: 'PENDING'
+        }
+      }
+    };
+
+    const action = resetResource('pasta');
+
+    const result = reducer(state, action);
+    expect(result).to.equal(state);
+  });
+
+  it('should not change the state when the action type does not match', () => {
+    const reducer = reset('books');
+
+    const state = {
+      selectedIds: [24],
+      resources: {
+        24: {name: 'James'}
+      },
+      meta: {
+        24: {oinky: true}
+      },
+      labels: {
+        pasta: {
+          ids: [24],
+          status: 'PENDING'
+        }
+      }
+    };
+
+    const action = {
+      type: 'OINK'
+    };
+
+    const result = reducer(state, action);
+    expect(result).to.equal(state);
+  });
+
+  it('should reset the slice when there is no label', () => {
+    const reducer = reset('books');
+
+    const state = {
+      selectedIds: [24],
+      resources: {
+        24: {name: 'James'}
+      },
+      meta: {
+        24: {oinky: true}
+      },
+      labels: {
+        pasta: {
+          ids: [24],
+          status: 'PENDING'
+        }
+      }
+    };
+
+    const action = resetResource('books');
+
+    const result = reducer(state, action);
+    expect(result).to.deep.equal({
+      resources: {},
+      meta: {},
+      labels: {}
+    });
+  });
+
+  it('should reset the label when there is a label', () => {
+    const reducer = reset('books');
+
+    const state = {
+      selectedIds: [24],
+      resources: {
+        24: {name: 'James'}
+      },
+      meta: {
+        24: {oinky: true}
+      },
+      labels: {
+        pasta: {
+          ids: [24],
+          status: 'PENDING'
+        },
+        spaghetti: {
+          ids: [100, 20],
+          status: 'SUCCEEDED'
+        }
+      }
+    };
+
+    const action = resetResource('books', 'spaghetti');
+
+    const result = reducer(state, action);
+    expect(result).to.deep.equal({
+      selectedIds: [24],
+      resources: {
+        24: {name: 'James'}
+      },
+      meta: {
+        24: {oinky: true}
+      },
+      labels: {
+        pasta: {
+          ids: [24],
+          status: 'PENDING'
+        },
+        spaghetti: {
+          ids: [],
+          status: 'NULL'
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
This adds a reset plugin, which is useful for clearing out unused data. As part of #89 

//cc @danteoh this can be used to clear out old data from the store to free up memory