### PR TITLE
Fix bundling of CJS modules

### DIFF
--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -26,9 +26,3 @@ import { resourceReducer } from 'resourceful-redux';
 ```js
 var resourceReducer = require('resourceful-redux').resourceReducer;
 ```
-
-#### ES5 (UMD build)
-
-```js
-var resourceReducer = resourcefulRedux.resourceReducer;
-```

--- a/packages/resourceful-action-creators/package.json
+++ b/packages/resourceful-action-creators/package.json
@@ -56,7 +56,6 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "6.23.0",
-    "babel-loader": "7.1.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-rewire": "^1.1.0",
@@ -70,7 +69,6 @@
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1",
     "webpack": "^3.1.0"
   },

--- a/packages/resourceful-action-creators/rollup.config.js
+++ b/packages/resourceful-action-creators/rollup.config.js
@@ -1,6 +1,5 @@
 import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
-import replace from 'rollup-plugin-replace';
 import uglify from 'rollup-plugin-uglify';
 import commonjs from 'rollup-plugin-commonjs';
 
@@ -19,9 +18,6 @@ var config = {
     }),
     babel({
       exclude: 'node_modules/**'
-    }),
-    replace({
-      'process.env.NODE_ENV': JSON.stringify(env)
     }),
     commonjs({
       include: 'node_modules/**',

--- a/packages/resourceful-plugins/package.json
+++ b/packages/resourceful-plugins/package.json
@@ -56,7 +56,6 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "6.23.0",
-    "babel-loader": "7.1.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-preset-env": "^1.6.0",
@@ -70,7 +69,6 @@
     "rollup": "^0.45.1",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1",
     "webpack": "^3.1.0"
   },

--- a/packages/resourceful-plugins/rollup.config.js
+++ b/packages/resourceful-plugins/rollup.config.js
@@ -1,6 +1,5 @@
 import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
-import replace from 'rollup-plugin-replace';
 import uglify from 'rollup-plugin-uglify';
 
 var env = process.env.NODE_ENV;
@@ -18,9 +17,6 @@ var config = {
     babel({
       exclude: 'node_modules/**'
     }),
-    replace({
-      'process.env.NODE_ENV': JSON.stringify(env)
-    })
   ]
 };
 

--- a/packages/resourceful-prop-types/package.json
+++ b/packages/resourceful-prop-types/package.json
@@ -59,7 +59,6 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "6.23.0",
-    "babel-loader": "7.1.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-preset-env": "^1.6.0",
@@ -72,7 +71,6 @@
     "rollup": "^0.45.1",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1",
     "webpack": "^3.1.0"
   },

--- a/packages/resourceful-prop-types/rollup.config.js
+++ b/packages/resourceful-prop-types/rollup.config.js
@@ -1,6 +1,5 @@
 import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
-import replace from 'rollup-plugin-replace';
 import uglify from 'rollup-plugin-uglify';
 
 var env = process.env.NODE_ENV;
@@ -18,9 +17,6 @@ var config = {
     babel({
       exclude: 'node_modules/**'
     }),
-    replace({
-      'process.env.NODE_ENV': JSON.stringify(env)
-    })
   ]
 };
 

--- a/packages/resourceful-redux/package.json
+++ b/packages/resourceful-redux/package.json
@@ -56,7 +56,6 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "6.23.0",
-    "babel-loader": "6.2.5",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-preset-env": "^1.6.0",
@@ -68,7 +67,6 @@
     "rollup": "^0.45.1",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1"
   },
   "peerDependencies": {

--- a/packages/resourceful-redux/rollup.config.js
+++ b/packages/resourceful-redux/rollup.config.js
@@ -1,6 +1,5 @@
 import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
-import replace from 'rollup-plugin-replace';
 import uglify from 'rollup-plugin-uglify';
 
 var env = process.env.NODE_ENV;
@@ -14,9 +13,6 @@ var config = {
     babel({
       exclude: 'node_modules/**'
     }),
-    replace({
-      'process.env.NODE_ENV': JSON.stringify(env)
-    })
   ]
 };
 


### PR DESCRIPTION
Resolves #179 

---

Note that this means the lib doesn't work in browser global environments without a special bit of polyfill code. I don't think anyone using the lib is using it like that right now, so it's probably fine. I'll make a separate issue to fix that.